### PR TITLE
Fixed handing of Crossref author with name field only

### DIFF
--- a/sciety_discovery/providers/crossref.py
+++ b/sciety_discovery/providers/crossref.py
@@ -14,6 +14,8 @@ LOGGER = logging.getLogger(__name__)
 def get_author_name_from_crossref_metadata_author_dict(
     author_dict: dict
 ) -> str:
+    if author_dict.get('name'):
+        return author_dict['name']
     return ' '.join([
         author_dict['given'],
         author_dict['family']

--- a/tests/unit_tests/providers/crossref_test.py
+++ b/tests/unit_tests/providers/crossref_test.py
@@ -20,7 +20,7 @@ class TestGetArticleMetadataFromCrossrefMetadata:
         )
         assert result.article_title == 'Title 1'
 
-    def test_should_extract_author_names(self):
+    def test_should_extract_author_names_from_given_and_family_name(self):
         result = get_article_metadata_from_crossref_metadata(
             DOI_1,
             {
@@ -33,4 +33,18 @@ class TestGetArticleMetadataFromCrossrefMetadata:
         )
         assert result.author_name_list == [
             'John Smith'
+        ]
+
+    def test_should_extract_author_names_from_name_field(self):
+        result = get_article_metadata_from_crossref_metadata(
+            DOI_1,
+            {
+                **CROSSREF_RESPONSE_MESSAGE_1,
+                'author': [{
+                    'name': 'John Smith Group'
+                }]
+            }
+        )
+        assert result.author_name_list == [
+            'John Smith Group'
         ]


### PR DESCRIPTION
An example can be found here `https://api.crossref.org/works/10.1101/2023.02.05.527215`:

```json
{"name":"Penn Medicine BioBank","sequence":"additional","affiliation":[]}
```